### PR TITLE
Simplify querying logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .Rapp.history
 .Rproj.user
+.Rhistory

--- a/R/cg_amendments.R
+++ b/R/cg_amendments.R
@@ -46,16 +46,13 @@ cg_amendments <- function(amendment_id=NULL, amendment_type=NULL, number=NULL, c
   key=getOption("SunlightLabsKey", stop("need an API key for Sunlight Labs")), return='table', ...)
 {
   url <- 'https://congress.api.sunlightfoundation.com/amendments'
-  args <- suncompact(list(apikey=key, amendment_id=amendment_id, amendment_type=amendment_type, 
-                          number=number, congress=congress, chamber=chamber, house_number=house_number, 
-                          introduced_on=introduced_on, last_action_at=last_action_at, 
-                          amends_bill_id=amends_bill_id,amends_treaty_id=amends_treaty_id, 
-                          amends_amendment_id=amends_amendment_id, sponsor_type=sponsor_type, 
-                          sponsor_id=sponsor_id, query=query, per_page=per_page, page=page, 
+  args <- suncompact(list(apikey=key, amendment_id=amendment_id, amendment_type=amendment_type,
+                          number=number, congress=congress, chamber=chamber, house_number=house_number,
+                          introduced_on=introduced_on, last_action_at=last_action_at,
+                          amends_bill_id=amends_bill_id,amends_treaty_id=amends_treaty_id,
+                          amends_amendment_id=amends_amendment_id, sponsor_type=sponsor_type,
+                          sponsor_id=sponsor_id, query=query, per_page=per_page, page=page,
                           fields=fields, order=order))
 
-  tt <- GET(url, query=args, ...)
-  stop_for_status(tt)
-  stopifnot(tt$headers$`content-type` == 'application/json; charset=utf-8')
-  return_obj(return, tt)
+  return_obj(return, query(url, args, ...))
 }

--- a/R/cg_bills.R
+++ b/R/cg_bills.R
@@ -94,10 +94,7 @@ cg_bills <- function(query = NULL, bill_id = NULL, bill_type = NULL, number = NU
     committee_ids=committee_ids, related_bill_ids=related_bill_ids, enacted_as.congress=enacted_as.congress,
     enacted_as.number=enacted_as.number))
 
-  tt <- GET(url, query=args, ...)
-  warn_for_status(tt)
-  stopifnot(tt$headers$`content-type` == 'application/json; charset=utf-8')
-  return_obj(return, tt)
+  return_obj(return, query(url, args, ...))
 }
 
 ll <- function(x) if(!is.null(x)){ if(x) tolower(x) else x }

--- a/R/cg_committees.R
+++ b/R/cg_committees.R
@@ -46,8 +46,5 @@ cg_committees <-  function(member_ids = NULL, committee_id = NULL, chamber = NUL
               chamber = chamber, subcommittee = subcommittee, fields = fields,
               parent_committee_id = parent_committee_id, page = page, per_page=per_page,
               query=query, order=order))
-  tt <- GET(url, query=args, ...)
-  stop_for_status(tt)
-  stopifnot(tt$headers$`content-type` == 'application/json; charset=utf-8')
-  return_obj(return, tt)
+  return_obj(return, query(url, args, ...))
 }

--- a/R/cg_districts.R
+++ b/R/cg_districts.R
@@ -27,8 +27,6 @@ cg_districts <- function(latitude = NULL, longitude = NULL, zip = NULL, query=NU
   url = "https://congress.api.sunlightfoundation.com/districts/locate"
   args <- suncompact(list(apikey = key, latitude = latitude, longitude = longitude, zip = zip,
                           query=query, per_page=per_page, page=page, order=order))
-  tt <- GET(url, query=args, ...)
-  warn_for_status(tt)
-  stopifnot(tt$headers$`content-type` == 'application/json; charset=utf-8')
-  return_obj(return, tt)
+
+  return_obj(return, query(url, args, ...))
 }

--- a/R/cg_floor_updates.R
+++ b/R/cg_floor_updates.R
@@ -29,19 +29,16 @@
 #' cg_floor_updates(chamber='house', query='Agreed to by voice vote')
 #' }
 
-cg_floor_updates <- function(chamber=NULL, timestamp=NULL, congress=NULL, legislative_day=NULL, 
-  year=NULL, bill_ids=NULL, roll_ids=NULL, legislator_ids=NULL, query=NULL, 
+cg_floor_updates <- function(chamber=NULL, timestamp=NULL, congress=NULL, legislative_day=NULL,
+  year=NULL, bill_ids=NULL, roll_ids=NULL, legislator_ids=NULL, query=NULL,
   fields=NULL, page=1, per_page=20, order=NULL,
   key=getOption("SunlightLabsKey", stop("need an API key for Sunlight Labs")), return='table', ...)
 {
   url <- 'https://congress.api.sunlightfoundation.com/floor_updates'
-  args <- suncompact(list(apikey=key, chamber=chamber, timestamp=timestamp, congress=congress, 
-                          legislative_day=legislative_day, year=year, bill_ids=bill_ids, 
-                          roll_ids=roll_ids, legislator_ids=legislator_ids, query=query, 
+  args <- suncompact(list(apikey=key, chamber=chamber, timestamp=timestamp, congress=congress,
+                          legislative_day=legislative_day, year=year, bill_ids=bill_ids,
+                          roll_ids=roll_ids, legislator_ids=legislator_ids, query=query,
                           per_page=per_page, page=page, fields=fields, order=order))
 
-  tt <- GET(url, query=args, ...)
-  stop_for_status(tt)
-  stopifnot(tt$headers$`content-type` == 'application/json; charset=utf-8')
-  return_obj(return, tt)
+  return_obj(return, query(url, args, ...))
 }

--- a/R/cg_hearings.R
+++ b/R/cg_hearings.R
@@ -8,7 +8,7 @@
 #' @param chamber (character) The chamber ('house', 'senate', or 'joint') of the committee holding the hearing.
 #' @param dc (logical) Whether the committee hearing is held in DC (TRUE) or in the field (FALSE).
 #' @param bill_ids (numeric) The IDs of any bills mentioned by or associated with the hearing.
-#' @param hearing_type (character) (House only) The type of hearing this is. Can be: 'Hearing', 
+#' @param hearing_type (character) (House only) The type of hearing this is. Can be: 'Hearing',
 #' 'Markup', 'Business Meeting', 'Field Hearing'.
 #'
 #' @template cg
@@ -23,14 +23,11 @@ cg_hearings <- function(committee_id=NULL, occurs_at=NULL, congress=NULL, chambe
   key=getOption("SunlightLabsKey", stop("need an API key for Sunlight Labs")), return='table', ...)
 {
   url <- 'https://congress.api.sunlightfoundation.com/hearings'
-  args <- suncompact(list(apikey=key, committee_id=committee_id, occurs_at=occurs_at, 
-      congress=congress, chamber=chamber, dc=getdc(dc), bill_ids=bill_ids, 
+  args <- suncompact(list(apikey=key, committee_id=committee_id, occurs_at=occurs_at,
+      congress=congress, chamber=chamber, dc=getdc(dc), bill_ids=bill_ids,
       hearing_type=hearing_type, query=query, per_page=per_page, page=page, fields=fields, order=order))
 
-  tt <- GET(url, query=args, ...)
-  stop_for_status(tt)
-  stopifnot(tt$headers$`content-type` == 'application/json; charset=utf-8')
-  return_obj(return, tt)
+  return_obj(return, query(url, args, ...))
 }
 
 getdc <- function(x){

--- a/R/cg_legislators.R
+++ b/R/cg_legislators.R
@@ -2,13 +2,13 @@
 #'
 #' @import httr
 #' @template getleg
-#' 
+#'
 #' @param latitude latitude of coordinate
 #' @param longitude longitude of coordinate
 #' @param zip zip code to search
 #' @template cg
 #' @template cg_query
-#' 
+#'
 #' @return List of output fields.
 #' @export
 #' @examples \dontrun{
@@ -18,15 +18,15 @@
 #' cg_legislators(facebook_id = 'mitchmcconnell')
 #' cg_legislators(latitude = 35.778788, longitude = -78.787805)
 #' cg_legislators(zip = 77006)
-#' 
+#'
 #' # Output a list
 #' cg_legislators(last_name = 'Pelosi', return='list')
 #' # Output an httr response object, for debugging purposes
 #' cg_legislators(last_name = 'Pelosi', return='response')
-#' 
+#'
 #' # Pagination
 #' cg_legislators(party = 'D', per_page=2)
-#' 
+#'
 #' # Curl debugging
 #' library('httr')
 #' cg_legislators(party = 'D', config=verbose())
@@ -35,13 +35,13 @@
 
 cg_legislators <- function(title=NULL, first_name=NULL, middle_name=NULL,
     last_name=NULL, name_suffix=NULL, nickname=NULL, party=NULL, state=NULL,
-    state_name=NULL, state_rank=NULL, district=NULL, in_office=NULL, chamber=NULL, 
-    gender=NULL, phone=NULL, fax=NULL, office=NULL, website=NULL, contact_form=NULL, 
-    email=NULL, congress_office=NULL, bioguide_id=NULL, ocd_id=NULL, thomas_id=NULL, 
-    lis_id=NULL, crp_id=NULL, icpsr_id=NULL, votesmart_id=NULL, fec_ids=NULL, 
+    state_name=NULL, state_rank=NULL, district=NULL, in_office=NULL, chamber=NULL,
+    gender=NULL, phone=NULL, fax=NULL, office=NULL, website=NULL, contact_form=NULL,
+    email=NULL, congress_office=NULL, bioguide_id=NULL, ocd_id=NULL, thomas_id=NULL,
+    lis_id=NULL, crp_id=NULL, icpsr_id=NULL, votesmart_id=NULL, fec_ids=NULL,
     govtrack_id=NULL, congresspedia_url=NULL, twitter_id=NULL, youtube_id=NULL,
     facebook_id=NULL, senate_class=NULL, term_start=NULL, term_end=NULL, birthday=NULL,
-    latitude = NULL, longitude = NULL, zip = NULL, query=NULL, fields=NULL, page=1, per_page=20, 
+    latitude = NULL, longitude = NULL, zip = NULL, query=NULL, fields=NULL, page=1, per_page=20,
     order=NULL,
     key=getOption("SunlightLabsKey", stop("need an API key for Sunlight Labs")), return='table',
     ...)
@@ -64,7 +64,7 @@ cg_legislators <- function(title=NULL, first_name=NULL, middle_name=NULL,
       stopifnot(is.null(latitude),is.null(longitude))
       args <- suncompact(list(apikey=key,zip=zip,per_page=per_page,page=page,fields=fields,query=query,order=order))
     }
-  } else {  
+  } else {
     url <- 'https://congress.api.sunlightfoundation.com/legislators'
     args <- suncompact(list(apikey=key,title=title,first_name=first_name,middle_name=middle_name,
         last_name=last_name,name_suffix=name_suffix,nickname=nickname,party=party,state=state,
@@ -77,9 +77,6 @@ cg_legislators <- function(title=NULL, first_name=NULL, middle_name=NULL,
         facebook_id=facebook_id,senate_class=senate_class,term_start=term_start,term_end=term_end,
         birthday=birthday,per_page=per_page,page=page,fields=fields,query=query,order=order))
   }
-  
-  tt <- GET(url, query=args, ...)
-  stop_for_status(tt)
-  stopifnot(tt$headers$`content-type` == 'application/json; charset=utf-8')
-  return_obj(return, tt)
+
+  return_obj(return, query(url, args, ...))
 }

--- a/R/cg_nominations.R
+++ b/R/cg_nominations.R
@@ -41,8 +41,5 @@ cg_nominations <- function(nomination_id=NULL, congress=NULL, number=NULL, recei
     nominees.state=nominees.state, query=query, per_page=per_page, page=page, fields=fields,
     order=order))
 
-  tt <- GET(url, query=args, ...)
-  stop_for_status(tt)
-  stopifnot(tt$headers$`content-type` == 'application/json; charset=utf-8')
-  return_obj(return, tt)
+  return_obj(return, query(url, args, ...))
 }

--- a/R/cg_upcoming_bills.R
+++ b/R/cg_upcoming_bills.R
@@ -40,13 +40,10 @@ cg_upcoming_bills <- function(scheduled_at=NULL, legislative_day=NULL, range=NUL
   key=getOption("SunlightLabsKey", stop("need an API key for Sunlight Labs")), return='table', ...)
 {
   url <- 'https://congress.api.sunlightfoundation.com/upcoming_bills'
-  args <- suncompact(list(apikey=key, scheduled_at=scheduled_at, legislative_day=legislative_day, 
-                          range=range, congress=congress, chamber=chamber, source_type=source_type, 
-                          bill_id=bill_id, per_page=per_page, page=page, fields=fields, 
+  args <- suncompact(list(apikey=key, scheduled_at=scheduled_at, legislative_day=legislative_day,
+                          range=range, congress=congress, chamber=chamber, source_type=source_type,
+                          bill_id=bill_id, per_page=per_page, page=page, fields=fields,
                           query=query, order=order))
 
-  tt <- GET(url, query=args, ...)
-  stop_for_status(tt)
-  stopifnot(tt$headers$`content-type` == 'application/json; charset=utf-8')
-  return_obj(return, tt)
+  return_obj(return, query(url, args, ...))
 }

--- a/R/cg_votes.R
+++ b/R/cg_votes.R
@@ -40,7 +40,7 @@
 #' direction is \code{desc}, because it is expected most queries will sort by a date. Any field
 #' which can be used for filtering may be used for sorting. On full-text search endpoints (URLs
 #' ending in \code{/search}), you may sort by score to order by relevancy.
-#' 
+#'
 #' @template cg_query
 #'
 #' @details Two parameters can be passed on that vary with vote and/or party plus vote:
@@ -70,8 +70,5 @@ cg_votes <- function(roll_id=NULL, chamber=NULL, number=NULL, year=NULL, congres
       required=required, result=result, bill_id=bill_id, nomination_id=nomination_id,
       per_page=per_page, page=page, fields=fields, order=order, ...))
 
-  tt <- GET(url, query=args, callopts)
-  stop_for_status(tt)
-  stopifnot(tt$headers$`content-type` == 'application/json; charset=utf-8')
-  return_obj(return, tt)
+  return_obj(return, query(url, args, callopts, ...))
 }

--- a/R/cw_dates.R
+++ b/R/cw_dates.R
@@ -11,14 +11,14 @@
 #' @param mincount Only return results where mentions are at or above the supplied threshold
 #' @param granularity The length of time covered by each result. Valid values:
 #'    'year', 'month', 'day' (default)
-#' @param entity_type The entity type to get top phrases for. One of 'date', 'month', 'state', or 
-#'    'legislator'. 
+#' @param entity_type The entity type to get top phrases for. One of 'date', 'month', 'state', or
+#'    'legislator'.
 #' @param entity_value The value of the entity given in \code{entity_type}. See Details.
 #' @return Data frame of observations by date.
 #' @export
 #' @details
-#' Formats for \code{entity_value} parameter are as follows: 
-#' 
+#' Formats for \code{entity_value} parameter are as follows:
+#'
 #' \itemize{
 #'  \item date: 2011-11-09
 #'  \item month: 201111
@@ -28,12 +28,12 @@
 #' @examples \dontrun{
 #' cw_dates(phrase='I would have voted', start_date='2001-01-20',
 #'    end_date='2009-01-20', granularity='year', party='D')
-#'    
+#'
 #' cw_dates(phrase='united states', entity_type='state',
 #'    entity_value='VA', granularity='year', party='D')
-#'    
+#'
 #' cw_dates(phrase='voting', start_date='2009-01-01',
-#'    end_date='2009-04-30', granularity='month', party='R')  
+#'    end_date='2009-04-30', granularity='month', party='R')
 #' }
 cw_dates <- function(phrase = NULL, title = NULL, date = NULL, start_date = NULL,
   end_date = NULL, chamber = NULL, state = NULL, party = NULL, bioguide_id = NULL,
@@ -50,8 +50,12 @@ cw_dates <- function(phrase = NULL, title = NULL, date = NULL, start_date = NULL
         session = session, cr_pages = cr_pages, volume = volume,
         page_id = page_id, n = n, mincount = mincount, granularity = granularity,
         percentages = percentages, entity_type=entity_type, entity_value=entity_value))
-  tt <- GET(url, query=args, ...)
-  stop_for_status(tt)
-  tmp <- return_obj(return, tt)
-  if(return=='response') tmp else tmp$results
+
+
+  tmp <- return_obj(return, query(url, args, ...))
+  if(return=='response'){
+    return(tmp)
+  } else {
+    return(tmp$results)
+  }
 }

--- a/R/cw_phrases.R
+++ b/R/cw_phrases.R
@@ -2,16 +2,16 @@
 #'
 #' @import httr
 #' @export
-#' @param entity_type The entity type to get top phrases for. One of 'date', 'month', 'state', or 
-#'    'legislator'. 
+#' @param entity_type The entity type to get top phrases for. One of 'date', 'month', 'state', or
+#'    'legislator'.
 #' @param entity_value The value of the entity given in \code{entity_type}. See Details.
 #' @param n The size of phrase, in words, to search for (up to 5).
-#' @param page The page of results to show. 100 results are shown at a time. To get more than 
+#' @param page The page of results to show. 100 results are shown at a time. To get more than
 #' 100 results, use the page parameter.
 #' @param per_page Number of records to return. Default: 20. Max: 50.
-#' @param sort The value on which to sort the results. You have to specify ascending or descending 
-#' (see details), but if you forget, we make it ascending by default (prevents 500 error :)). 
-#' Valid values are 'tfidf' (default) and 'count'. 
+#' @param sort The value on which to sort the results. You have to specify ascending or descending
+#' (see details), but if you forget, we make it ascending by default (prevents 500 error :)).
+#' Valid values are 'tfidf' (default) and 'count'.
 #' @param key Your SunlightLabs API key; loads from .Rprofile.
 #' @param ... Further curl options (debugging tools mostly)
 #' @param return (character) One of table (default), list, or response (httr response object).
@@ -20,11 +20,11 @@
 #' cw_phrases(entity_type='month', entity_value=201007)
 #' cw_phrases(entity_type='state', entity_value='NV')
 #' cw_phrases(entity_type='legislator', entity_value='L000551')
-#' 
+#'
 #' library('httr')
 #' head(cw_phrases(entity_type='month', entity_value=201007, config=verbose()))
 #' }
-cw_phrases <- function(entity_type = NULL, entity_value = NULL, n = NULL, page = NULL, 
+cw_phrases <- function(entity_type = NULL, entity_value = NULL, n = NULL, page = NULL,
   per_page = NULL, sort = NULL, return='table',
   key=getOption("SunlightLabsKey", stop("need an API key for Sunlight Labs")), ...)
 {
@@ -33,9 +33,7 @@ cw_phrases <- function(entity_type = NULL, entity_value = NULL, n = NULL, page =
     if(!grepl('asc|desc', sort))
       sort <- paste(sort, 'asc')
   }
-  args <- suncompact(list(apikey = key, entity_type=entity_type, entity_value=entity_value, 
+  args <- suncompact(list(apikey = key, entity_type=entity_type, entity_value=entity_value,
                           n=n, page=page, per_page=per_page, sort=sort))
-  tt <- GET(url, query=args, ...)
-  stop_for_status(tt)
-  return_obj(return, tt)
+  return_obj(return, query(url, args, ...))
 }

--- a/R/cw_text.R
+++ b/R/cw_text.R
@@ -61,8 +61,10 @@ cw_text <- function(phrase=NULL, title=NULL, date = NULL, start_date=NULL, end_d
       date = date, end_date=end_date, chamber=chamber, state=state, party=party,
       bioguide_id=bioguide_id, congress=congress, session=session, cr_pages=cr_pages, volume=volume,
       page=page, sort=sort))
-  out <- GET(url, query=args, ...)
-  stop_for_status(out)
-  tmp <- return_obj(return, out)
-  if(return=='response') tmp else tmp$results
+  tmp <- return_obj(return, query(url, args, ...))
+  if(return=='response'){
+    return(tmp)
+  } else {
+    return(tmp$results)
+  }
 }

--- a/R/cw_timeseries.R
+++ b/R/cw_timeseries.R
@@ -75,10 +75,9 @@ cw_timeseries <- function(phrase=NULL, date = NULL, start_date=NULL, end_date=NU
                        party=party, bioguide_id=bioguide_id, mincount=mincount,
                        percentages=percentages, granularity=granularity,
                        entity_type=entity_type, entity_value=entity_value))
-  tt <- GET(url, query=args, ...)
-  stop_for_status(tt)
-  tmp <- return_obj(return, tt)
-  if(return %in% c('response','list')){ tmp } else { 
+
+  tmp <- return_obj(return, query(url, args, ...))
+  if(return %in% c('response','list')){ tmp } else {
     data <- tmp$results
     if(granularity=='day'){ data$day <- as.Date(data$day) } else
       if(granularity=='month'){ data$month <- as.Date(sprintf("%s-01", sapply(data$month, splitt))) } else

--- a/R/ie_contr.R
+++ b/R/ie_contr.R
@@ -1,28 +1,28 @@
 #' Search for itemized campaign contributions
-#' 
+#'
 #' Search for itemized campaign contributions at the federal (FEC) or state (NIMSP) level.
-#' 
+#'
 #' @import httr
-#' @param amount The amount of the contribution in US dollars in one of the following formats: 
-#' 500 (exactly 500 dollars), >|500 (greater than or equal to 500 dollars), <|500 (less than or 
+#' @param amount The amount of the contribution in US dollars in one of the following formats:
+#' 500 (exactly 500 dollars), >|500 (greater than or equal to 500 dollars), <|500 (less than or
 #' equal to 500 dollars)
 #' @param contributor_ft Full-text search on name of individual, PAC, organization, or employer.
 #' @param contributor_state Two-letter abbreviation of state from which the contribution was made.
 #' @param cycle A YYYY formatted year (1990 - 2010) as a single year or YYYY|YYYY for an OR logic.
-#' @param date date of the contribution in ISO date format (with ><|2006-08-06|2006-09-12 as a 
+#' @param date date of the contribution in ISO date format (with ><|2006-08-06|2006-09-12 as a
 #' between-dates search).
-#' @param for_against Either \dQuote{for} or \dQuote{against}. When organizations run ads against 
-#' a candidate, they are counted as independent expenditures with the candidate as the recipient. 
-#' This parameter can be used to filter contributions meant for the candidate and those meant to 
+#' @param for_against Either \dQuote{for} or \dQuote{against}. When organizations run ads against
+#' a candidate, they are counted as independent expenditures with the candidate as the recipient.
+#' This parameter can be used to filter contributions meant for the candidate and those meant to
 #' be against the candidate.
 #' @param organization_ft Full-text search on employer, organization, and parent organization.
 #' @param recipient_ft Full-text search on name of PAC or candidate receiving the contribution.
-#' @param recipient_state Two-letter abbreviation of state in which the candidate receiving the 
+#' @param recipient_state Two-letter abbreviation of state in which the candidate receiving the
 #' contribution is running.
-#' @param seat Type of office being sought: \dQuote{federal:senate}, \dQuote{federal:house}, 
-#' \dQuote{federal:president}, \dQuote{state:upper}, \dQuote{state:lower}, or 
+#' @param seat Type of office being sought: \dQuote{federal:senate}, \dQuote{federal:house},
+#' \dQuote{federal:president}, \dQuote{state:upper}, \dQuote{state:lower}, or
 #' \dQuote{state:governor}. Use a pipe to separate multiple offices for an OR logic.
-#' @param transaction_namespace Filters on federal or state contributions: 
+#' @param transaction_namespace Filters on federal or state contributions:
 #' \dQuote{urn:fec:transaction} (federal) or \dQuote{urn:nimsp:transaction} (state).
 #' @template ie
 #' @return Details on campaign contributions.
@@ -48,7 +48,7 @@ ie_contr <-  function(
     page = NULL,
     per_page = NULL, return='table',
     key=getOption("SunlightLabsKey", stop("need an API key for Sunlight Labs")),
-    ...) 
+    ...)
 {
   url <- "http://transparencydata.com/api/1.0/contributions.json"
   args <- suncompact(list(apikey = key, amount = amount,
@@ -56,8 +56,5 @@ ie_contr <-  function(
     date = date, for_against = for_against, organization_ft = organization_ft,
     recipient_ft = recipient_ft, recipient_state = recipient_state, seat = seat,
     transaction_namespace = transaction_namespace, page = page, per_page = per_page))
-  tt <- GET(url, query=args, ...)
-  stop_for_status(tt)
-  stopifnot(tt$headers$`content-type` == 'application/json; charset=utf-8')
-  return_obj(return, tt)
+  return_obj(return, query(url, args, ...))
 }

--- a/R/ie_contr_bundled.R
+++ b/R/ie_contr_bundled.R
@@ -1,5 +1,5 @@
 #' Search for itemized bundlers.
-#' 
+#'
 #' @import httr
 #' @export
 #' @param lobbyist_name Lobbyist name
@@ -17,10 +17,7 @@ ie_contr_bundled <-  function(lobbyist_name = NULL, recipient_name = NULL, page 
   ...)
 {
   url <- "http://transparencydata.com/api/1.0/contributions/bundled.json"
-  args <- suncompact(list(apikey = key, lobbyist_name = lobbyist_name, 
+  args <- suncompact(list(apikey = key, lobbyist_name = lobbyist_name,
               recipient_name = recipient_name, page = page, per_page = per_page))
-  tt <- GET(url, query=args, ...)
-  stop_for_status(tt)
-  stopifnot(tt$headers$`content-type` == 'application/json; charset=utf-8')
-  return_obj(return, tt)
+  return_obj(return, query(url, args, ...))
 }

--- a/R/ie_earmarks.R
+++ b/R/ie_earmarks.R
@@ -1,5 +1,5 @@
 #' Search itemized earmark requests through FY 2010.
-#' 
+#'
 #' @import httr
 #' @param amount (integer) The final amount of the earmark.
 #' @param bill (character) The bill, section or subsection of the earmark.
@@ -23,17 +23,14 @@
 #' ie_earmarks(description='Infantry Support')
 #' }
 
-ie_earmarks <- function(amount = NULL, bill = NULL, city = NULL, description = NULL, member = NULL, 
-  member_party = NULL, member_state = NULL, recipient = NULL, year = NULL, page = NULL, 
-  per_page = NULL, return='table', key=getOption("SunlightLabsKey", stop("need an API key for Sunlight Labs")), ...) 
+ie_earmarks <- function(amount = NULL, bill = NULL, city = NULL, description = NULL, member = NULL,
+  member_party = NULL, member_state = NULL, recipient = NULL, year = NULL, page = NULL,
+  per_page = NULL, return='table', key=getOption("SunlightLabsKey", stop("need an API key for Sunlight Labs")), ...)
 {
   url <- "http://transparencydata.com/api/1.0/earmarks.json"
-  args <- suncompact(list(apikey = key, amount = amount, bill = bill, city = city, 
-    description = description, member = member, member_party = member_party, 
-    member_state = member_state, recipient = recipient, year = year, page = page, 
+  args <- suncompact(list(apikey = key, amount = amount, bill = bill, city = city,
+    description = description, member = member, member_party = member_party,
+    member_state = member_state, recipient = recipient, year = year, page = page,
     per_page = per_page))
-  tt <- GET(url, query=args, ...)
-  stop_for_status(tt)
-  stopifnot(tt$headers$`content-type` == 'application/json; charset=utf-8')
-  return_obj(return, tt)
+  return_obj(return, query(url, args, ...))
 }

--- a/R/ie_entities.R
+++ b/R/ie_entities.R
@@ -61,8 +61,5 @@ ie_entities <- function(search = NULL, type = NULL, namespace = NULL, id = NULL,
 
   args <- suncompact(list(apikey = key, search = search, type = type, id = id,
           namespace = namespace, bioguide_id = bioguide_id, page=page, per_page=per_page))
-  tt <- GET(url, query=args, ...)
-  stop_for_status(tt)
-  stopifnot(tt$headers$`content-type` == 'application/json; charset=utf-8')
-  return_obj(return, tt)
+  return_obj(return, query(url, args, ...))
 }

--- a/R/ie_epa.R
+++ b/R/ie_epa.R
@@ -1,12 +1,12 @@
 #' Search itemized EPA enforcement actions.
-#' 
+#'
 #' @import httr
 #' @param case_name (character) The name of the enforcement case.
 #' @param case_num (character) One or more specific case numbers.
 #' @param defendants (character) Full-text search for the name(s) of the defendant companies.
-#' @param first_date (character) Start of a date range of the most recent date of significance to 
+#' @param first_date (character) Start of a date range of the most recent date of significance to
 #' the case in ISO format.
-#' @param last_date (character) End of a date range of the most recent date of significance to the 
+#' @param last_date (character) End of a date range of the most recent date of significance to the
 #' case in ISO format.
 #' @param location_addresses (character) Full-text search on all addresses associated with the case.
 #' @param penalty (integer) Total penalties, in US dollars.
@@ -20,16 +20,13 @@
 #' ie_epa(defendants='Massey Energy', first_date='>|2005-01-01')
 #' }
 
-ie_epa <- function(case_name = NULL, case_num = NULL, defendants = NULL, first_date = NULL, 
+ie_epa <- function(case_name = NULL, case_num = NULL, defendants = NULL, first_date = NULL,
   last_date = NULL, location_addresses = NULL, penalty = NULL, page = NULL, return='table',
-  per_page = NULL, key=getOption("SunlightLabsKey", stop("need an API key for Sunlight Labs")), ...) 
+  per_page = NULL, key=getOption("SunlightLabsKey", stop("need an API key for Sunlight Labs")), ...)
 {
   url <- "http://transparencydata.com/api/1.0/epa.json"
-  args <- suncompact(list(apikey = key, case_name = case_name, case_num = case_num, 
-    defendants = defendants, first_date = first_date, last_date = last_date, 
+  args <- suncompact(list(apikey = key, case_name = case_name, case_num = case_num,
+    defendants = defendants, first_date = first_date, last_date = last_date,
     location_addresses = location_addresses, penalty = penalty, page = page, per_page = per_page))
-  tt <- GET(url, query=args, ...)
-  stop_for_status(tt)
-  stopifnot(tt$headers$`content-type` == 'application/json; charset=utf-8')
-  return_obj(return, tt)
+  return_obj(return, query(url, args, ...))
 }

--- a/R/ie_faca.R
+++ b/R/ie_faca.R
@@ -1,5 +1,5 @@
 #' Search for itemized Federal Advisory Committee memberships.
-#' 
+#'
 #' @import httr
 #' @param affiliation (character) The name of the affiliated organization.
 #' @param agency_name (character) The name of the agency associated with the committee.
@@ -17,16 +17,13 @@
 #' ie_faca(committee_name='2010 Census Advisory Committee', per_page=1)
 #' }
 
-ie_faca <- function(affiliation = NULL, agency_name = NULL, committee_name = NULL, member_name = NULL, 
+ie_faca <- function(affiliation = NULL, agency_name = NULL, committee_name = NULL, member_name = NULL,
   year = NULL, page = NULL, per_page = NULL, return='table',
-  key=getOption("SunlightLabsKey", stop("need an API key for Sunlight Labs")), ...) 
+  key=getOption("SunlightLabsKey", stop("need an API key for Sunlight Labs")), ...)
 {
   url <- "http://transparencydata.com/api/1.0/faca.json"
-  args <- suncompact(list(apikey = key, affiliation = affiliation, agency_name = agency_name, 
-    committee_name = committee_name, member_name = member_name, year=year, page = page, 
+  args <- suncompact(list(apikey = key, affiliation = affiliation, agency_name = agency_name,
+    committee_name = committee_name, member_name = member_name, year=year, page = page,
     per_page = per_page))
-  tt <- GET(url, query=args, ...)
-  stop_for_status(tt)
-  stopifnot(tt$headers$`content-type` == 'application/json; charset=utf-8')
-  return_obj(return, tt)
+  return_obj(return, query(url, args, ...))
 }

--- a/R/ie_getcontracts.R
+++ b/R/ie_getcontracts.R
@@ -31,7 +31,7 @@
 #' @export
 #' @examples \dontrun{
 #' ie_contracts(vendor_city='indianapolis', page=1, per_page=5)
-#' 
+#'
 #' library('httr')
 #' ie_contracts(vendor_city='indianapolis', page=1, per_page=5, config=verbose())[,c(1:5)]
 #' }
@@ -70,8 +70,5 @@ ie_contracts <-  function(
     vendor_city = vendor_city, vendor_district = vendor_district, vendor_duns = vendor_duns,
     vendor_name = vendor_name, vendor_parent_duns = vendor_parent_duns, vendor_state = vendor_state,
     vendor_zipcode = vendor_zipcode, page = page, per_page = per_page))
-  tt <- GET(url, query=args, ...)
-  stop_for_status(tt)
-  stopifnot(tt$headers$`content-type` == 'application/json; charset=utf-8')
-  return_obj(return, tt)
+  return_obj(return, query(url, args, ...))
 }

--- a/R/ie_getgrants.R
+++ b/R/ie_getgrants.R
@@ -1,5 +1,5 @@
 #' Get federal grant details
-#' 
+#'
 #' @import httr
 #' @template ie
 #' @param agency_ft Full-text search on the reported name of the federal agency awarding the grant.
@@ -25,15 +25,12 @@ ie_grants <-  function(
     page = NULL,
     per_page = NULL,  return='table',
     key=getOption("SunlightLabsKey", stop("need an API key for Sunlight Labs")),
-    ...) 
+    ...)
 {
   url <- "http://transparencydata.com/api/1.0/grants.json"
   args <- suncompact(list(apikey = key, agency_ft = agency_ft,
     amount_total = amount_total, assistance_type = assistance_type, fiscal_year = fiscal_year,
     recipient_ft = recipient_ft, recipient_state = recipient_state, recipient_type = recipient_type,
     page = page, per_page = per_page))
-  tt <- GET(url, query=args, ...)
-  stop_for_status(tt)
-  stopifnot(tt$headers$`content-type` == 'application/json; charset=utf-8')
-  return_obj(return, tt)
+  return_obj(return, query(url, args, ...))
 }

--- a/R/ie_getlobbying.R
+++ b/R/ie_getlobbying.R
@@ -1,5 +1,5 @@
 #' Get lobbying details
-#' 
+#'
 #' @import httr
 #' @template ie
 #' @param amount A YYYY formatted year (1990 - 2010) as a single year or YYYY|YYYY for an OR logic.
@@ -29,15 +29,12 @@ ie_lobbying <-  function(
     page = NULL,
     per_page = NULL, return='table',
     key=getOption("SunlightLabsKey", stop("need an API key for Sunlight Labs")),
-    ...) 
+    ...)
 {
   url <- "http://transparencydata.com/api/1.0/lobbying.json"
   args <- suncompact(list(apikey = key, amount = amount,
     client_ft = client_ft, client_parent_ft = client_parent_ft, filing_type = filing_type,
     lobbyist_ft = lobbyist_ft, registrant_ft = registrant_ft, transaction_id = transaction_id,
     transaction_type = transaction_type, year = year, page = page, per_page = per_page))
-  tt <- GET(url, query=args, ...)
-  stop_for_status(tt)
-  stopifnot(tt$headers$`content-type` == 'application/json; charset=utf-8')
-  return_obj(return, tt)
+  return_obj(return, query(url, args, ...))
 }

--- a/R/ie_individuals.R
+++ b/R/ie_individuals.R
@@ -58,8 +58,5 @@ ie_individuals <- function(method = NULL, entity_id = NULL, cycle = NULL, limit 
   if(method=="top_ind") limit <- NULL
   args <- suncompact(list(apikey = key, cycle = cycle, limit = limit))
 
-  tt <- GET(url, query=args, ...)
-  stop_for_status(tt)
-  stopifnot(tt$headers$`content-type` == 'application/json; charset=utf-8')
-  return_obj(return, tt)
+  return_obj(return, query(url, args, ...))
 }

--- a/R/ie_industries.R
+++ b/R/ie_industries.R
@@ -33,8 +33,5 @@ ie_industries <- function(method = NULL, entity_id = NULL, cycle = NULL, limit =
   if(method=="top_org") limit <- NULL
   args <- suncompact(list(apikey = key, cycle = cycle, limit = limit))
 
-  tt <- GET(url, query=args, ...)
-  stop_for_status(tt)
-  stopifnot(tt$headers$`content-type` == 'application/json; charset=utf-8')
-  return_obj(return, tt)
+  return_obj(return, query(url, args, ...))
 }

--- a/R/ie_misconduct.R
+++ b/R/ie_misconduct.R
@@ -1,5 +1,5 @@
 #' Search for itemized misconduct incident reports
-#' 
+#'
 #' @import httr
 #' @param contractor (character)	The name of the contractor to search for.
 #' @param contracting_party (character)  The FIPS code for the contracting agency.
@@ -14,24 +14,21 @@
 #' ie_misconduct(contractor='SAIC', date_year=2012)
 #' ie_misconduct(instance='Castle Harbour Tax Shelter')
 #' ie_misconduct(date_year=2012, per_page=2)
-#' 
+#'
 #' ie_misconduct(penalty_amount=5000000)
 #' ie_misconduct(contractor='GlaxoSmithKline', per_page=3)
 #' }
 
 ie_misconduct <- function(contractor = NULL, contracting_party = NULL, date_year = NULL,
   enforcement_agency = NULL, instance = NULL, penalty_amount = NULL, page = NULL, per_page = NULL,
-  return='table', key=getOption("SunlightLabsKey", stop("need an API key for Sunlight Labs")), ...) 
+  return='table', key=getOption("SunlightLabsKey", stop("need an API key for Sunlight Labs")), ...)
 {
   if(!is.null(penalty_amount)) penalty_amount <- as.integer(penalty_amount)
   url <- "http://transparencydata.com/api/1.0/misconduct.json"
-  args <- suncompact(list(apikey = key, contractor = contractor, 
-    contracting_party = contracting_party, date_year = date_year, enforcement_agency = enforcement_agency, 
+  args <- suncompact(list(apikey = key, contractor = contractor,
+    contracting_party = contracting_party, date_year = date_year, enforcement_agency = enforcement_agency,
     instance = instance, penalty_amount = penalty_amount, page = page, per_page = per_page))
-  tt <- GET(url, query=args, ...)
-  stop_for_status(tt)
-  stopifnot(tt$headers$`content-type` == 'application/json; charset=utf-8')
-  tmp <- return_obj(return, tt)
+  tmp <- return_obj(return, query(url, args, ...))
   tmp$penalty_amount <- format(tmp$penalty_amount, scientific = FALSE)
   tmp
 }

--- a/R/ie_organizations.R
+++ b/R/ie_organizations.R
@@ -94,8 +94,5 @@ ie_organizations <- function(method = NULL, entity_id = NULL, cycle = NULL, limi
   if(method=="top_org") limit <- NULL
   args <- suncompact(list(apikey = key, cycle = cycle, limit = limit))
 
-  tt <- GET(url, query=args, ...)
-  stop_for_status(tt)
-  stopifnot(tt$headers$`content-type` == 'application/json; charset=utf-8')
-  return_obj(return, tt)
+  return_obj(return, query(url, args, ...))
 }

--- a/R/ie_politicians.R
+++ b/R/ie_politicians.R
@@ -68,8 +68,5 @@ ie_politicians <- function(method = NULL, entity_id = NULL, cycle = NULL, limit 
   if(method=="top_pol") limit <- NULL
   args <- suncompact(list(apikey = key, cycle = cycle, limit = limit))
 
-  tt <- GET(url, query=args, ...)
-  stop_for_status(tt)
-  stopifnot(tt$headers$`content-type` == 'application/json; charset=utf-8')
-  return_obj(return, tt)
+  return_obj(return, query(url, args, ...))
 }

--- a/R/os_billlookup.R
+++ b/R/os_billlookup.R
@@ -2,7 +2,7 @@
 #'
 #' @import httr
 #' @importFrom stringr str_extract ignore.case
-#' 
+#'
 #' @param state state two-letter abbreviation (character), required
 #' @param session session of congress (integer), e.g., 2009-2010 = 20092010,
 #'    required
@@ -23,16 +23,16 @@
 #' os_billlookup(state='ca', session=20092010, bill_id='AB 667')
 #' os_billlookup(state='ca', session=20092010, bill_id='AB 667', per_page=1)
 #' os_billlookup(state='ca', session=20092010, bill_id='AB 667', per_page=1, fields='id')
-#' os_billlookup(state='ca', session=20092010, bill_id='AB 667', 
+#' os_billlookup(state='ca', session=20092010, bill_id='AB 667',
 #'    per_page=3, fields=c('id','title'))
 #' os_billlookup(state='ca', session=20092010, bill_id='SB 425')
 #' os_billlookup(state='ca', session=20092010, bill_id=c('AB 667','SB 425'))
-#' 
+#'
 #' library('httr')
 #' os_billlookup(state='ca', session=20092010, bill_id='AB 667', config=verbose(), per_page=1)
 #' }
 
-os_billlookup <- function(state = NULL, session = NULL, bill_id = NULL, 
+os_billlookup <- function(state = NULL, session = NULL, bill_id = NULL,
   fields = NULL, per_page = NULL, page = NULL, return='table',
   key = getOption("SunlightLabsKey", stop("need an API key for Sunlight Labs")), ...)
 {
@@ -42,9 +42,7 @@ os_billlookup <- function(state = NULL, session = NULL, bill_id = NULL,
     bills <- paste(bill_id, collapse = "|")
     bill_id <- NULL
   }
-  args <- suncompact(list(apikey=key, state=state, session=session, bill_id=bill_id, 
+  args <- suncompact(list(apikey=key, state=state, session=session, bill_id=bill_id,
           bill_id__in=bills, per_page=per_page, page=page, fields=paste(fields, collapse = ",")))
-  tt <- GET(url, query=args, ...)
-  stop_for_status(tt)
-  return_obj(return, tt)
+  return_obj(return, query(url, args, ...))
 }

--- a/R/os_billsearch.R
+++ b/R/os_billsearch.R
@@ -20,13 +20,13 @@
 #'    subject parameters are supplied then only bills that match all of
 #'    them will be returned. See list of subjects
 #' @param type (character) Only bills of a given type (e.g. 'bill', 'resolution', etc.)
-#' @param search_window By default all bills are searched, but if a time window is desired the 
-#' following options can be passed to search_window: all (Default, include all sessions.), 
-#' term (Only bills from sessions within the current term.), session (Only bills from the current 
-#' session.), session:2009 (Only bills from the session named 2009.), term:2009-2011 (Only bills 
+#' @param search_window By default all bills are searched, but if a time window is desired the
+#' following options can be passed to search_window: all (Default, include all sessions.),
+#' term (Only bills from sessions within the current term.), session (Only bills from the current
+#' session.), session:2009 (Only bills from the session named 2009.), term:2009-2011 (Only bills
 #' from the sessions in the 2009-2011 session.)
-#' @param sort (character) One of 'first' (default), 'last', 'signed', 'passed_lower', 
-#'    'passed_upper', 'updated_at', or 'created_at'. 
+#' @param sort (character) One of 'first' (default), 'last', 'signed', 'passed_lower',
+#'    'passed_upper', 'updated_at', or 'created_at'.
 #' @param fields You can request specific fields by supplying a vector of fields names. Many fields
 #' are not returned unless requested. If you don't supply a fields parameter, you will get the
 #' most commonly used subset of fields only. To save on bandwidth, parsing time, and confusion,
@@ -46,13 +46,13 @@
 #' os_billsearch(terms = 'taxi', state = 'dc', per_page=3)
 #' os_billsearch(terms = 'taxi', state = 'dc', per_page=3, sort='created_at')
 #' os_billsearch(terms = 'taxi', state = 'dc', type='resolution')
-#' 
+#'
 #' # Search window
 #' length(os_billsearch(terms = 'climate change', search_window='term'))
 #' length(os_billsearch(terms = 'climate change', search_window='term:2009-2011'))
 #' length(os_billsearch(terms = 'climate change', search_window='session'))
 #' length(os_billsearch(terms = 'climate change', search_window='session:2009'))
-#' 
+#'
 #' os_billsearch(terms = 'agriculture', state = 'tx', per_page=2)
 #' os_billsearch(terms = 'agriculture', state = 'tx', per_page=2, page=2)
 #' os_billsearch(terms = 'agriculture', state = 'tx', fields=c('id','created_at'), per_page=10)
@@ -66,10 +66,8 @@ os_billsearch <- function(terms = NULL, state = NULL, window = NULL,
   url = "http://openstates.org/api/v1/bills/"
   args <- suncompact(list(apikey = key, q = terms, state = state, window = window,
                        chamber = chamber, sponsor_id = sponsor_id,
-                       updated_since = updated_since, subject = subject, type=type, 
+                       updated_since = updated_since, subject = subject, type=type,
                        search_window=search_window, sort=sort, page=page, per_page=per_page,
                        fields=paste(fields, collapse = ",")))
-  tt <- GET(url, query=args, ...)
-  stop_for_status(tt)
-  return_obj(return, tt)
+  return_obj(return, query(url, args, ...))
 }

--- a/R/os_legislatorsearch.R
+++ b/R/os_legislatorsearch.R
@@ -1,7 +1,7 @@
 #' Search Legislators on OpenStates.
 #'
 #' @import httr
-#' 
+#'
 #' @param state state two-letter abbreviation (character)
 #' @param first_name first name of legislator (character)
 #' @param last_name last name of legislator (character)
@@ -27,7 +27,7 @@
 #' os_legislatorsearch(state = 'tx', party = 'democratic', active = TRUE)
 #' os_legislatorsearch(state = 'nv', party = 'republican')
 #' os_legislatorsearch(state = 'dc', chamber = 'upper')
-#' 
+#'
 #' os_legislatorsearch(state = 'ca', party = 'democratic', per_page=3)
 #' }
 os_legislatorsearch <- function(state = NULL, first_name = NULL,
@@ -39,9 +39,7 @@ os_legislatorsearch <- function(state = NULL, first_name = NULL,
   url = "http://openstates.org/api/v1/legislators/"
   args <- suncompact(list(apikey = key, state = state, first_name = first_name,
                        last_name = last_name, chamber = chamber, active = active,
-                       term = term, district = district, party = party, 
+                       term = term, district = district, party = party,
                        page=page, per_page=per_page, fields=paste(fields, collapse = ",")))
-  tt <- GET(url, query=args, ...)
-  stop_for_status(tt)
-  return_obj(return, tt)
+  return_obj(return, query(url, args, ...))
 }

--- a/R/query.R
+++ b/R/query.R
@@ -1,0 +1,20 @@
+query <- function(url, args, ...){
+
+  #Query
+  query_results <- GET(url, query=args, ...)
+
+  #Check status. 403s are the most likely and we don't want to be just providing a shouty "403 FORBIDDEN";
+  #we know why those show up and can be reasonable about it.
+  status <- query_results$all_headers[[1]]$status
+  if(status == 403){
+    stop("Your connection was not authorised: you have either not provided an API key, or provided
+         an invalid one. Please see ?rsunlight")
+  }
+
+  #Check status against remaining options, check returned type.
+  stop_for_status(status)
+  stopifnot(query_results$headers$`content-type` == 'application/json; charset=utf-8')
+
+  #Assuming it hasn't blown up by now, return
+  return(query_results)
+}


### PR DESCRIPTION
This commit takes the querying logic from each function and moves it into a single function (called, aptly, query). The consequence of this is:
1. os_\* functions now check the returned type (they previously didn't);
2. 403s can be handled as a special case rather than simply using stop_for_status, since the source of those problems is obvious enough to let us provide an informative error message that points to the rsunlight documentation;
3. We save ~60 SLOC and only need to tweak one thing if the query structure or results structure changes, rather than tweaking, ah. 32 different things.

As side-effects I've discovered a few bugs and idiosyncracies I'll report; I've also modified the logic in cw_dates to use explicit return() calls and split the if/elses across multiple lines, since it makes the code more readable.
