### PR TITLE
remove endless httr imports

### DIFF
--- a/R/cg_bills.R
+++ b/R/cg_bills.R
@@ -9,7 +9,6 @@
 #'  debate.
 #' }
 #'
-#' @import httr jsonlite
 #' @export
 #' @template bills
 #' @template cg

--- a/R/cg_committees.R
+++ b/R/cg_committees.R
@@ -1,6 +1,6 @@
-#' Gets details (subcommittees + membership) for a committee by id.
+#' @title Gets details (subcommittees + membership) for a committee by id.
 #'
-#' Names, IDs, contact info, and memberships of committees and subcommittees in the House and
+#' @description Names, IDs, contact info, and memberships of committees and subcommittees in the House and
 #' Senate. All committee information is sourced from bulk data at github.com/unitedstates, which
 #' in turn comes from official House and Senate sources . Feel free to open a ticket with any
 #' bugs or suggestions. We only provide information on current committees and memberships. For

--- a/R/cg_districts.R
+++ b/R/cg_districts.R
@@ -1,6 +1,5 @@
 #' Get districts for a latitude/longitude or zips
 #'
-#' @import httr
 #' @export
 #' @param latitude (numeric) latitude of coordinate
 #' @param longitude (numeric) longitude of coordinate

--- a/R/cg_legislators.R
+++ b/R/cg_legislators.R
@@ -1,6 +1,5 @@
 #' Search for legislators.
 #'
-#' @import httr
 #' @template getleg
 #'
 #' @param latitude latitude of coordinate

--- a/R/cw_dates.R
+++ b/R/cw_dates.R
@@ -1,7 +1,6 @@
 #' Capitol words dates.json method. Search the congressional record for
 #' instances of a word or phrase over time.
 #'
-#' @import httr
 #' @template cw
 #' @template cw_dates_text
 #' @param page_id Page id.

--- a/R/cw_phrases.R
+++ b/R/cw_phrases.R
@@ -1,6 +1,5 @@
 #' Capitol words phrases.json method. List the top phrases for a facet.
 #'
-#' @import httr
 #' @export
 #' @param entity_type The entity type to get top phrases for. One of 'date', 'month', 'state', or
 #'    'legislator'.

--- a/R/cw_text.R
+++ b/R/cw_text.R
@@ -1,7 +1,6 @@
 #' Capitol words text.json method. Search the congressional record for instances
 #' of a word or phrase.
 #'
-#' @import httr
 #' @template cw
 #' @template cw_dates_text
 #' @param page The page of results to show, 50 results are shown at a time.

--- a/R/cw_timeseries.R
+++ b/R/cw_timeseries.R
@@ -1,6 +1,5 @@
 #' Find the popularity of a phrase over a period of time.
 #'
-#' @import httr
 #' @importFrom plyr rbind.fill
 #' @importFrom stringr str_sub
 #' @template cw

--- a/R/ie_contr.R
+++ b/R/ie_contr.R
@@ -2,7 +2,6 @@
 #'
 #' Search for itemized campaign contributions at the federal (FEC) or state (NIMSP) level.
 #'
-#' @import httr
 #' @param amount The amount of the contribution in US dollars in one of the following formats:
 #' 500 (exactly 500 dollars), >|500 (greater than or equal to 500 dollars), <|500 (less than or
 #' equal to 500 dollars)

--- a/R/ie_contr_bundled.R
+++ b/R/ie_contr_bundled.R
@@ -1,6 +1,5 @@
 #' Search for itemized bundlers.
 #'
-#' @import httr
 #' @export
 #' @param lobbyist_name Lobbyist name
 #' @param recipient_name Recipient name

--- a/R/ie_earmarks.R
+++ b/R/ie_earmarks.R
@@ -1,6 +1,5 @@
 #' Search itemized earmark requests through FY 2010.
 #'
-#' @import httr
 #' @param amount (integer) The final amount of the earmark.
 #' @param bill (character) The bill, section or subsection of the earmark.
 #' @param city (character) The city where the money will be spent.

--- a/R/ie_entities.R
+++ b/R/ie_entities.R
@@ -2,7 +2,6 @@
 #'
 #' Search for politicians, individuals, or organizations with the given name.
 #'
-#' @import httr
 #' @export
 #' @param search (character) The query string. There are no logic operators or grouping.
 #' @param type (character) Filter results to a particular type of entity. One of politician,

--- a/R/ie_epa.R
+++ b/R/ie_epa.R
@@ -1,6 +1,5 @@
 #' Search itemized EPA enforcement actions.
 #'
-#' @import httr
 #' @param case_name (character) The name of the enforcement case.
 #' @param case_num (character) One or more specific case numbers.
 #' @param defendants (character) Full-text search for the name(s) of the defendant companies.

--- a/R/ie_faca.R
+++ b/R/ie_faca.R
@@ -1,6 +1,5 @@
 #' Search for itemized Federal Advisory Committee memberships.
 #'
-#' @import httr
 #' @param affiliation (character) The name of the affiliated organization.
 #' @param agency_name (character) The name of the agency associated with the committee.
 #' @param committee_name (character) The name of the advisory committee.

--- a/R/ie_getcontracts.R
+++ b/R/ie_getcontracts.R
@@ -1,6 +1,5 @@
 #' Get federal contract details
 #'
-#' @import httr
 #' @template ie
 #' @param agency_id The FIPS code for the agency.
 #' @param agency_name Full-text search on the name of the agency.

--- a/R/ie_getgrants.R
+++ b/R/ie_getgrants.R
@@ -1,6 +1,5 @@
 #' Get federal grant details
 #'
-#' @import httr
 #' @template ie
 #' @param agency_ft Full-text search on the reported name of the federal agency awarding the grant.
 #' @param amount_total Total amount of the grant in US dollars in one of the following formats: 500 (exactly 500 dollars), >|500 (greater than or equal to 500 dollars), <|500 (less than or equal to 500 dollars)

--- a/R/ie_getlobbying.R
+++ b/R/ie_getlobbying.R
@@ -1,6 +1,5 @@
 #' Get lobbying details
 #'
-#' @import httr
 #' @template ie
 #' @param amount A YYYY formatted year (1990 - 2010) as a single year or YYYY|YYYY for an OR logic.
 #' @param client_ft Full-text search on the name of the client for which the lobbyist is working.

--- a/R/ie_individuals.R
+++ b/R/ie_individuals.R
@@ -1,6 +1,5 @@
 #' Politician aggregrates: Search for contributions to politicians.
 #'
-#' @import httr
 #' @export
 #' @param method (character) The query string. One of top_ind, top_recorg, top_recpol,
 #' party_breakdown, lobb_reg, lobb_cli, or lobb_iss.

--- a/R/ie_industries.R
+++ b/R/ie_industries.R
@@ -1,6 +1,5 @@
 #' Organization aggregates: Search for contributions to politicians.
 #'
-#' @import httr
 #' @export
 #' @param method (character) The query string. One of top_ind or top_org.
 #' @param entity_id (character) The transparencydata ID to look up.

--- a/R/ie_misconduct.R
+++ b/R/ie_misconduct.R
@@ -1,6 +1,5 @@
 #' Search for itemized misconduct incident reports
 #'
-#' @import httr
 #' @param contractor (character)	The name of the contractor to search for.
 #' @param contracting_party (character)  The FIPS code for the contracting agency.
 #' @param date_year (numeric) The year in which a date significant to the incident occurred.

--- a/R/ie_organizations.R
+++ b/R/ie_organizations.R
@@ -1,6 +1,5 @@
 #' Organization aggregates: Search for contributions to politicians.
 #'
-#' @import httr
 #' @export
 #' @param method (character) The query string. One of top_org, top_rec, pac_rec, party_breakdown,
 #' level_breakdown, registrants, issues, bills, lobbyists, reg_clients, reg_issues, or reg_bills.

--- a/R/ie_politicians.R
+++ b/R/ie_politicians.R
@@ -1,6 +1,5 @@
 #' Politician aggregrates: Search for contributions to politicians.
 #'
-#' @import httr
 #' @export
 #' @param method (character) The query string. One of top_pol, top_con, unk_ind, top_ind, top_sec,
 #' local_breakdown, type_breakdown, fec_summary, fec_indexp

--- a/R/os_billlookup.R
+++ b/R/os_billlookup.R
@@ -1,6 +1,5 @@
 #' Lookup bills on OpenStates.
 #'
-#' @import httr
 #' @importFrom stringr str_extract ignore.case
 #'
 #' @param state state two-letter abbreviation (character), required

--- a/R/os_billsearch.R
+++ b/R/os_billsearch.R
@@ -1,7 +1,5 @@
 #' Search OpenStates bills.
 #'
-#' @import httr
-#'
 #' @param terms search terms bill search (character)
 #' @param state state two-letter abbreviation (character)
 #' @param window a string representing what time period to search across.

--- a/R/os_legislatorsearch.R
+++ b/R/os_legislatorsearch.R
@@ -1,7 +1,5 @@
 #' Search Legislators on OpenStates.
 #'
-#' @import httr
-#'
 #' @param state state two-letter abbreviation (character)
 #' @param first_name first name of legislator (character)
 #' @param last_name last name of legislator (character)

--- a/R/os_statemetasearch.R
+++ b/R/os_statemetasearch.R
@@ -1,6 +1,5 @@
 #' Search OpenStates metadata.
 #'
-#' @import httr
 #' @param state One or more two-letter state abbreviations (character)
 #' @param key your SunlightLabs API key; or loads from .Rprofile
 #' @param ... Curl options passed on to httr::GET

--- a/R/rsunlight-package.R
+++ b/R/rsunlight-package.R
@@ -24,6 +24,7 @@
 #' @title Sunlight Foundation client for R.
 #' @author Scott Chamberlain \email{myrmecocystus@@gmail.com}
 #' @keywords package
+#' @import httr jsonlite
 NULL
 
 #' Sunlight Labs Influence Explorer API sector code and names to use for searching/retreiving data.

--- a/R/sunlight_tocsv.R
+++ b/R/sunlight_tocsv.R
@@ -3,7 +3,7 @@
 #' @keywords internal
 #' @param x Output from any of the rsunlight functions.
 #' @param file File name, with path.
-#' @param ... Further args passed to read.csv
+#' @param ... Further arguments passed to read.csv
 #' @details This function attemps to coerce the raw output from each rsunlight function to a
 #' data.frame to write to csv, but it may fail in some cases. You can always make your own
 #' data.frame.

--- a/man/sunlight_tocsv.Rd
+++ b/man/sunlight_tocsv.Rd
@@ -28,7 +28,7 @@ sunlight_tocsv(x, file = "~/", ...)
 
 \item{file}{File name, with path.}
 
-\item{...}{Further args passed to read.csv}
+\item{...}{Further arguments passed to read.csv}
 }
 \description{
 Write data from any rsunlight function output to a csv file on your machine.


### PR DESCRIPTION
rsunlight is dependent on httr. A vast number of functions contain import tags in their documentation that import httr, as a result. This is, however, inconsistent (some functions that use it, don't document that they use it), unnecessary (all querying has been moved to query() now anyway) and duplicative (one import tag is quite enough to have roxygen2 modify the NAMESPACE file appropriately).

This change removes all of the <code>@import httr</code> lines from rsunlight, replacing them with a single import tag in the rsunlight-package documentation.
