### PR TITLE
fix inaccuracy in os_billsearch documentation.

### DIFF
--- a/R/os_billsearch.R
+++ b/R/os_billsearch.R
@@ -35,7 +35,7 @@
 #' @param return (character) One of table (default), list, or response (httr response object)
 #' @param key your SunlightLabs API key; loads from .Rprofile
 #' @param ... Optional additional curl options (debugging tools mostly). See examples.
-#' @return List of output fields.
+#' @return a data.frame of bills.
 #' @export
 #' @examples \dontrun{
 #' os_billsearch(terms = 'agriculture', state = 'tx')

--- a/man/os_billsearch.Rd
+++ b/man/os_billsearch.Rd
@@ -63,7 +63,7 @@ it's recommended to always specify which fields you will be using.}
 \item{...}{Optional additional curl options (debugging tools mostly). See examples.}
 }
 \value{
-List of output fields.
+a data.frame of bills.
 }
 \description{
 Search OpenStates bills.


### PR DESCRIPTION
os_billsearch's documentation claims it returns a list; it actually returns a data.frame (awkwardly, some columns within that data.frame consist of lists, which makes sense (you can have multiple values for some fields)).

This tweaks the documentation to make clear it returns a df; there's a bug here, but what that bug _is_ depends on what the intended behaviour is. Is the intent to return a list? If so, the code is buggy. Alternately, if the intent is to return a data.frame, I see at least one field that we could almost certainly unlist. Up to you which bug gets opened + patch because I don't know the design intent, here.